### PR TITLE
Update copyright header with new repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2024 Tobias Briones. All rights reserved. -->
+<!-- This file is part of https://github.com/mathswe/legal -->
+
 # Legal
 
 [![GitHub Repository](https://img.shields.io/static/v1?label=GITHUB&message=REPOSITORY&labelColor=555&color=0277bd&style=for-the-badge&logo=GITHUB)](https://github.com/mathswe/legal)

--- a/cookie-consent/README.md
+++ b/cookie-consent/README.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2024 Tobias Briones. All rights reserved. -->
+<!-- This file is part of https://github.com/mathswe/legal -->
+
 # Cookie Consent
 
 It processes the MathSwe cookie consent operations such as storing consent

--- a/cookie-consent/src/anonymous_ip.rs
+++ b/cookie-consent/src/anonymous_ip.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2024 Tobias Briones. All rights reserved.
-// This file is part of https://github.com/mathswe/lambda
+// This file is part of https://github.com/mathswe/legal
 
 use std::net::Ipv4Addr;
 use serde::{Deserialize, Serialize};

--- a/cookie-consent/src/client_req.rs
+++ b/cookie-consent/src/client_req.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2024 Tobias Briones. All rights reserved.
-// This file is part of https://github.com/mathswe/lambda
+// This file is part of https://github.com/mathswe/legal
 
 use strum::IntoEnumIterator;
 use worker::{Error, Request};

--- a/cookie-consent/src/consent.rs
+++ b/cookie-consent/src/consent.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2024 Tobias Briones. All rights reserved.
-// This file is part of https://github.com/mathswe/lambda
+// This file is part of https://github.com/mathswe/legal
 
 use chrono::{DateTime, Utc};
 use nanoid::nanoid;

--- a/cookie-consent/src/cookie_consent.rs
+++ b/cookie-consent/src/cookie_consent.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2024 Tobias Briones. All rights reserved.
-// This file is part of https://github.com/mathswe/lambda
+// This file is part of https://github.com/mathswe/legal
 
 use std::net::Ipv4Addr;
 use std::str::FromStr;

--- a/cookie-consent/src/geolocation.rs
+++ b/cookie-consent/src/geolocation.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2024 Tobias Briones. All rights reserved.
-// This file is part of https://github.com/mathswe/lambda
+// This file is part of https://github.com/mathswe/legal
 
 use std::str::FromStr;
 use serde::{Deserialize, Serialize};

--- a/cookie-consent/src/lib.rs
+++ b/cookie-consent/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2024 Tobias Briones. All rights reserved.
-// This file is part of https://github.com/mathswe/lambda
+// This file is part of https://github.com/mathswe/legal
 
 use worker::*;
 

--- a/cookie-consent/src/server.rs
+++ b/cookie-consent/src/server.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2024 Tobias Briones. All rights reserved.
-// This file is part of https://github.com/mathswe/lambda
+// This file is part of https://github.com/mathswe/legal
 
 use std::fmt::Display;
 use worker::{console_log, Cors, Error, Method, Request, Response, RouteContext};


### PR DESCRIPTION
The repo changed from "mathswe/lambda" to "mathswe/legal."